### PR TITLE
fix missing emit

### DIFF
--- a/Lavevel-Token.sol
+++ b/Lavevel-Token.sol
@@ -174,5 +174,7 @@ contract LavevelToken is Token {
   function LavevelToken() public {
     totalSupply = INITIAL_SUPPLY;
     balances[msg.sender] = INITIAL_SUPPLY;
+    emit Transfer(address(0), msg.sender, INITIAL_SUPPLY);
+
   }
 }


### PR DESCRIPTION
based on the protocol, a Transfer event should be emitted.
“A token contract which creates new tokens SHOULD trigger a Transfer event with the _from address set to 0x0 when tokens are created.”
from https://eips.ethereum.org/EIPS/eip-20

So this fix just simply emits a transfer event when a new token is created.